### PR TITLE
Removing Python 3.9> types

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,3 @@
-import pprint
 import omegaup.api
 import sys
 import os
@@ -6,10 +5,6 @@ import math
 import mosspy
 
 from util import get_credentials_from_file, print_table, path_exists
-
-
-pp = pprint.PrettyPrinter(indent=4)
-
 
 def display_admin_contests(contest_class):
     contests = contest_class.adminList()
@@ -56,7 +51,7 @@ def display_contest_problems(contest_class, contest_alias):
 def get_runs_from_problem(contest_class, run_class, contest_alias, problem_alias):
     runs = contest_class.runs(contest_alias=contest_alias, problem_alias=problem_alias)
 
-    print("\n Getting runs from problem: " + problem_alias)
+    print("\nGetting runs from problem: " + problem_alias)
     # separate runs by username
     runs_by_username = {}
     for run in runs["runs"]:
@@ -191,7 +186,7 @@ def remove_same_user_matches(report_path, filtered_report_path, problem_alias):
     )
 
 
-def get_user_from_html_line(line, problem_alias) -> str:
+def get_user_from_html_line(line, problem_alias):
     search_index = line.index(problem_alias) + len(problem_alias) + 1
     # Now find the user
     user_index = line.index("/", search_index)

--- a/util.py
+++ b/util.py
@@ -3,7 +3,7 @@ import os.path
 from mosspy import moss
 
 
-def get_credentials_from_file(file_name: str):
+def get_credentials_from_file(file_name):
     """
     Reads the login credentials from the file. If they are not there, then it will ask for them and write them to the file.
     """
@@ -25,7 +25,7 @@ def get_credentials_from_file(file_name: str):
     return username, password, moss_user_id
 
 
-def print_table(rows: list[str]):
+def print_table(rows):
     """
     Prints a table with the given columns.
     """


### PR DESCRIPTION
Arreglará el error que marca al correr con versiones antiguas de Python como 3.8

Fixes: #1 